### PR TITLE
Update ibcprotocol link

### DIFF
--- a/academy/3-ibc/1-what-is-ibc.md
+++ b/academy/3-ibc/1-what-is-ibc.md
@@ -251,7 +251,7 @@ Do you have access to an existing chain?
 
 </ExpansionPanel>
 
-The most straightforward way to use IBC is to build a chain with the Cosmos SDK, which already includes the IBC module - as you can see when examining the [ibc-go repository](https://github.com/cosmos/ibc-go). The IBC module supports an out-of-the-box CometBFT light client. Other implementations are possible but may require further development of the necessary components; go to the [IBC website](https://ibcprotocol.org/implementations) to see which implementations are available in production or are being developed.
+The most straightforward way to use IBC is to build a chain with the Cosmos SDK, which already includes the IBC module - as you can see when examining the [ibc-go repository](https://github.com/cosmos/ibc-go). The IBC module supports an out-of-the-box CometBFT light client. Other implementations are possible but may require further development of the necessary components; go to the [IBC website](https://www.ibcprotocol.dev/blog/getting-started-with-ibc-understanding-the-interchain-stack-and-the-main-ibc-implementations) to see which implementations are available in production or are being developed.
 
 <HighlightBox type="info">
 


### PR DESCRIPTION
This PR updates the link to the ibcprotocol website on https://tutorials.cosmos.network/academy/3-ibc/1-what-is-ibc.html to point to the new domain ibcprotocol.dev (and the new file path for https://www.ibcprotocol.dev/blog/getting-started-with-ibc-understanding-the-interchain-stack-and-the-main-ibc-implementations)

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [x] Small content fixes
* [ ] Addition of new content
* [ ] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
