### PR TITLE
fix: makefile referring to wrong command

### DIFF
--- a/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
+++ b/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
@@ -99,7 +99,7 @@ do-checksum-darwin:
         checkersd-darwin-amd64 checkersd-darwin-arm64 \
         > checkers-checksum-darwin
 
-build-darwin-with-checksum: build-all-darwin do-checksum-darwin
+build-darwin-with-checksum: build-darwin do-checksum-darwin
 
 build-with-checksum: build-linux-with-checksum build-darwin-with-checksum
 ```


### PR DESCRIPTION
Documentation content update for `Run in Prod: 1.Run Prod Docker -> The node image`

This PR fixes the wrong command referred in the makefile for building darwin bin files
Referenced [here](https://github.com/cosmos/b9-checkers-academy-draft/issues/66)

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [x] Small content fixes
* [ ] Addition of new content
* [x] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
