### PR TITLE
docs: Fix typo

### DIFF
--- a/academy/3-ibc/1-what-is-ibc.md
+++ b/academy/3-ibc/1-what-is-ibc.md
@@ -78,7 +78,7 @@ Note three crucial elements in the diagram:
 
 <HighlightBox type="info">
 
-If you're interested in another overview of the IBC protocol, in the following video Callum Waters, Engineering Manager for the Tendermind Core, gives a talk on the methodology allowing interoperability between countless sovereign blockchains and how to build an IBC-compatible app.
+If you're interested in another overview of the IBC protocol, in the following video Callum Waters, Engineering Manager for the Tendermint Core, gives a talk on the methodology allowing interoperability between countless sovereign blockchains and how to build an IBC-compatible app.
 
 <YoutubePlayer videoId="OSMH5uwTssk"/>
 


### PR DESCRIPTION
Documentation content update for "[Introduction to the Interchain](https://tutorials.cosmos.network/academy/1-what-is-cosmos/)" "[What is IBC?](https://tutorials.cosmos.network/academy/3-ibc/1-what-is-ibc.html)"

This PR fixes a "Tendermind" typo.

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [x] Small language/grammar fixes
* [ ] Small content fixes
* [ ] Addition of new content
* [ ] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
